### PR TITLE
FIX tradução de chapéu

### DIFF
--- a/DefInjected/ApparelLayerDef/ApparelLayerDefs.xml
+++ b/DefInjected/ApparelLayerDef/ApparelLayerDefs.xml
@@ -11,7 +11,7 @@
   <OnSkin.label>pele</OnSkin.label>
   
   <!-- EN: headgear -->
-  <Overhead.label>chapel</Overhead.label>
+  <Overhead.label>chapéu</Overhead.label>
   
   <!-- EN: outer -->
   <Shell.label>exterior</Shell.label>


### PR DESCRIPTION
Outra possibilidade para tradução seria "chapelaria", que aí sim se escreve com L e não U.